### PR TITLE
Logging improvements and fix timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.4.1 (October 17, 2020)
 
 - Better error logging when fetching from Secrets Manager
-- Updated httpOptions to use timeout instead of connectTimeout.
+- Updated `httpOptions` to use `timeout` instead of `connectTimeout`
 - Use args interface for loadSecrets function.
 
 ## 1.4.0 (November 28, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Better error logging when fetching from Secrets Manager
 - Updated `httpOptions` to use `timeout` instead of `connectTimeout`
-- Use args interface for loadSecrets function.
 
 ## 1.4.0 (November 28, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.1 (October 17, 2020)
 
-- Better error logging when fetching AWS Secrets.
+- Better error logging when fetching from Secrets Manager
 - Updated httpOptions to use timeout instead of connectTimeout.
 - Use args interface for loadSecrets function.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.1 (October 17, 2020)
+
+- Better error logging when fetching AWS Secrets.
+- Updated httpOptions to use timeout instead of connectTimeout.
+- Use args interface for loadSecrets function.
+
 ## 1.4.0 (November 28, 2019)
 
 - Add support for APP_ENV

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-dug",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Config loader with support for AWS Secrets Manager",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/src/get-secret.ts
+++ b/src/get-secret.ts
@@ -7,13 +7,18 @@ const getSecret = (secretName: string, region: string, timeout: number): object 
     const secret = awsParamStore.getParameterSync(`/aws/reference/secretsmanager/${secretName}`, {
       region,
       httpOptions: {
-        connectTimeout: timeout
+        timeout
       }
     });
 
     return JSON.parse(secret.Value);
   } catch (error) {
-    console.error('ERROR: Unable to get secret from AWS Secrets Manager');
+    console.error('ERROR: Unable to get secret from AWS Secrets Manager', {
+      secretName,
+      region,
+      timeout
+    });
+
     console.error(error);
 
     return {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,15 @@ interface ConfigObject {
   [key: string]: string | boolean | number;
 }
 
+interface LoadSecretsArgs {
+  AWS_SECRETS_MANAGER_NAME?: string;
+  AWS_SECRETS_MANAGER_REGION?: string;
+  AWS_SECRETS_MANAGER_TIMEOUT?: number;
+  awsSecretsManagerName?: string;
+  awsSecretsManagerRegion?: string;
+  awsSecretsManagerTimeout?: number;
+}
+
 const resolveFile = (appDirectory: string, configPath: string, fileName: string): string => {
   if (fs.existsSync(path.resolve(appDirectory, configPath, `${fileName}.ts`))) {
     debug(
@@ -62,14 +71,7 @@ const convertString = (value: string): string | number | boolean => {
   return value;
 };
 
-const loadSecrets = (config: {
-  AWS_SECRETS_MANAGER_NAME?: string;
-  AWS_SECRETS_MANAGER_REGION?: string;
-  AWS_SECRETS_MANAGER_TIMEOUT?: number;
-  awsSecretsManagerName?: string;
-  awsSecretsManagerRegion?: string;
-  awsSecretsManagerTimeout?: number;
-}): object => {
+const loadSecrets = (config: LoadSecretsArgs): object => {
   const secretName = config.AWS_SECRETS_MANAGER_NAME || config.awsSecretsManagerName;
   const region = config.AWS_SECRETS_MANAGER_REGION || config.awsSecretsManagerRegion || 'us-east-1';
   const timeout = config.AWS_SECRETS_MANAGER_TIMEOUT || config.awsSecretsManagerTimeout || 5000;


### PR DESCRIPTION
- Updated error logging to include ```SecretName / Region / Timeout```.
- Fixed timeout.
- Updated ```loadSecrets``` function to use interface.

Output example:
```
ERROR: Unable to get secret from AWS Secrets Manager {
  secretName: 'env/service/config',
  region: 'ca-central-1',
  timeout: 100
}
Error: Connection timed out after 100ms
```