### PR TITLE
Do not warn in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.1 (October 17, 2020)
+
+- Suppress secret undefined warning if running tests
+
 ## 1.5.0 (October 17, 2020)
 
 - Add support for multiple AWS Secrets Manager secrets in the same region

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.5.1 (October 17, 2020)
+## 1.5.1 (October 21, 2020)
 
 - Suppress secret undefined warning if running tests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-dug",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Config loader with support for AWS Secrets Manager",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,11 @@ const loadConfig = (configPath = ''): ConfigObject => {
   );
   const config = Object.assign({}, fileConfig, loadSecrets(fileConfig), loadEnvironment());
 
-  return validateConfig(config);
+  if (environment === 'test') {
+    return config;
+  } else {
+    return validateConfig(config);
+  }
 };
 
 const init = (): ConfigObject => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -79,7 +79,9 @@ test('loading invalid config does nothing', (): void => {
   expect(typeof invalidConfig).toBe('object');
 });
 
-test('config value that is undefined causes a warning', (): void => {
+test('config value that is undefined causes a warning when env is not test', (): void => {
+  process.env.APP_ENV = 'staging';
+
   jest.spyOn(global.console, 'warn');
 
   loadConfig('test/fixtures/validate');
@@ -87,4 +89,19 @@ test('config value that is undefined causes a warning', (): void => {
   expect(console.warn).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
   expect(console.warn).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
   expect(console.warn).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
+
+  jest.clearAllMocks();
+  process.env.APP_ENV = 'test';
+});
+
+test('config value that is undefined does not cause a warning when env is test', (): void => {
+  jest.spyOn(global.console, 'warn');
+
+  loadConfig('test/fixtures/validate');
+
+  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
+  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
+  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
+
+  jest.clearAllMocks();
 });


### PR DESCRIPTION
This new warning on undefined configs was too noisy if a test file was using config-dug.

This skips the validation call if the environment is test.