### PR TITLE
CH26934 - Do not validate configs in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.6.2 (December 4, 2020)
 
 - Update all console warnings to console logs
-- Do not validate configs in developments
+- Do not validate configs in development
 
 ## 1.6.1 (November 13, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.6.2 (December 4, 2020)
 
-- Update all warnings to logs
+- Update all console warnings to console logs
 - Do not validate configs in developments
 
 ## 1.6.1 (November 13, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.2 (November 13, 2020)
+
+- Update all warnings to logs
+- Do not validate configs in developments
+
 ## 1.6.1 (November 13, 2020)
 
 - Update yarn.lock for security warning on `kind-of`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.6.2 (November 13, 2020)
+## 1.6.2 (December 4, 2020)
 
 - Update all warnings to logs
 - Do not validate configs in developments

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-dug",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Config loader with support for AWS Secrets Manager",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ const loadConfig = (configPath = ''): ConfigObject => {
   );
   const config = Object.assign({}, fileConfig, loadSecrets(fileConfig), loadEnvironment());
 
-  if (environment === 'test') {
+  if (environment === 'test' || environment === 'development') {
     return config;
   } else {
     return validateConfig(config);

--- a/src/validate-config.ts
+++ b/src/validate-config.ts
@@ -12,11 +12,11 @@ const validateConfig = (config: ConfigObject): ConfigObject => {
     const value = config[key];
 
     if (value === undefined || value === null || value === 'undefined' || value === '') {
-      console.warn(`WARNING: Found undefined config value for ${key}`);
+      console.log(`WARNING: Found undefined config value for ${key}`);
     }
 
     if (typeof value === 'string' && hasTrailingOrLeadingWhitespace(value)) {
-      console.warn(
+      console.log(
         `WARNING: Found leading and/or trailing whitespace within config value for ${key}`
       );
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -82,13 +82,13 @@ test('loading invalid config does nothing', (): void => {
 test('config value that is undefined causes a warning when env is not test', (): void => {
   process.env.APP_ENV = 'staging';
 
-  jest.spyOn(global.console, 'warn');
+  jest.spyOn(global.console, 'log');
 
   loadConfig('test/fixtures/validate');
 
-  expect(console.warn).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
-  expect(console.warn).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
-  expect(console.warn).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
+  expect(console.log).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
+  expect(console.log).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
+  expect(console.log).toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
 
   jest.clearAllMocks();
   process.env.APP_ENV = 'test';
@@ -97,26 +97,26 @@ test('config value that is undefined causes a warning when env is not test', ():
 test('config value that is undefined does not cause a warning when env is development', (): void => {
   process.env.APP_ENV = 'development';
 
-  jest.spyOn(global.console, 'warn');
+  jest.spyOn(global.console, 'log');
 
   loadConfig('test/fixtures/validate');
 
-  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
-  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
-  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
+  expect(console.log).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
+  expect(console.log).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
+  expect(console.log).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
 
   jest.clearAllMocks();
   process.env.APP_ENV = 'test';
 });
 
 test('config value that is undefined does not cause a warning when env is test', (): void => {
-  jest.spyOn(global.console, 'warn');
+  jest.spyOn(global.console, 'log');
 
   loadConfig('test/fixtures/validate');
 
-  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
-  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
-  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
+  expect(console.log).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
+  expect(console.log).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
+  expect(console.log).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
 
   jest.clearAllMocks();
 });
@@ -124,17 +124,17 @@ test('config value that is undefined does not cause a warning when env is test',
 test('loading config values with leading and/or trailing whitespace causes a warning', (): void => {
   process.env.APP_ENV = 'staging';
 
-  const spy = jest.spyOn(global.console, 'warn').mockImplementation(() => jest.fn());
+  const spy = jest.spyOn(global.console, 'log').mockImplementation(() => jest.fn());
 
   loadConfig('test/fixtures/validate');
 
-  expect(console.warn).toHaveBeenCalledWith(
+  expect(console.log).toHaveBeenCalledWith(
     'WARNING: Found leading and/or trailing whitespace within config value for KEY_6'
   );
-  expect(console.warn).toHaveBeenCalledWith(
+  expect(console.log).toHaveBeenCalledWith(
     'WARNING: Found leading and/or trailing whitespace within config value for KEY_7'
   );
-  expect(console.warn).toHaveBeenCalledWith(
+  expect(console.log).toHaveBeenCalledWith(
     'WARNING: Found leading and/or trailing whitespace within config value for KEY_8'
   );
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -94,6 +94,21 @@ test('config value that is undefined causes a warning when env is not test', ():
   process.env.APP_ENV = 'test';
 });
 
+test('config value that is undefined does not cause a warning when env is development', (): void => {
+  process.env.APP_ENV = 'development';
+
+  jest.spyOn(global.console, 'warn');
+
+  loadConfig('test/fixtures/validate');
+
+  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_3');
+  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_4');
+  expect(console.warn).not.toHaveBeenCalledWith('WARNING: Found undefined config value for KEY_5');
+
+  jest.clearAllMocks();
+  process.env.APP_ENV = 'test';
+});
+
 test('config value that is undefined does not cause a warning when env is test', (): void => {
   jest.spyOn(global.console, 'warn');
 


### PR DESCRIPTION
Sending warnings out during development for undefined configs is much too noisy and doesn't provide enough value to be worth it.

In all other envs the warnings shouldn't be too noisy if you follow these guidelines when setting your configs:
- All configs can be defined in `config.default` for readability purposes
- If your config is set in `config.default` to `undefined` or `''` then it should also be set to a value in all other config files
- If your config is set in `config.default` to a value, then you only need to define it in config files in which you wish to overwrite the value

Also, as a side note the `console.warn` was being written to stderr - so using `console.log` while keeping the "WARNING" message is preferred.