### PR TITLE
Add options to `loadConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0 (December 21, 2020)
+
+- Add options to `loadConfig` to specify the sources to load from
+
 ## 1.6.2 (December 4, 2020)
 
 - Update all console warnings to console logs

--- a/README.md
+++ b/README.md
@@ -124,10 +124,18 @@ If you want to load config files from a directory other than the project root yo
 ```ts
 import { loadConfig } from 'config-dug';
 
-loadConfig('config');
+loadConfig('config', { files: true, environment: false, secrets: false });
 ```
 
 This will import your config files from the `config` directory. The path you specify must be relative to your project root.
+
+The second parameter contains options to specify where to load configs from. By default, Config Dug will load from all possible sources.
+
+| Option        | Default | Description                        |
+| ------------- | ------- | ---------------------------------- |
+| `files`       | `true`  | loads from `config.[env].js` files |
+| `environment` | `true`  | loads from `process.env`           |
+| `secrets`     | `true`  | loads from AWS Secrets Manager     |
 
 ### Debugging
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-dug",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Config loader with support for AWS Secrets Manager",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,13 +141,8 @@ const loadEnvironment = (): object => {
   }, {});
 };
 
-const loadFiles = (configPath: string): object => {
+const loadFiles = (configPath: string, environment: string): object => {
   const appDirectory = fs.realpathSync(process.cwd());
-  const environment = process.env.APP_ENV
-    ? process.env.APP_ENV
-    : process.env.NODE_ENV
-    ? process.env.NODE_ENV
-    : 'development';
 
   debug('loading config from', path.resolve(appDirectory, configPath));
 
@@ -177,7 +172,13 @@ const loadConfig = (configPath = '', options: LoadConfigOptions = {}): ConfigObj
     secrets: enableSecrets = true
   } = options;
 
-  const fileConfig = enableFiles ? loadFiles(configPath) : {};
+  const environment = process.env.APP_ENV
+    ? process.env.APP_ENV
+    : process.env.NODE_ENV
+    ? process.env.NODE_ENV
+    : 'development';
+
+  const fileConfig = enableFiles ? loadFiles(configPath, environment) : {};
   const secretsConfig = enableSecrets ? loadSecrets(fileConfig) : {};
   const environmentConfig = enableEnvironment ? loadEnvironment() : {};
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -141,3 +141,13 @@ test('loading config values with leading and/or trailing whitespace causes a war
   spy.mockRestore();
   process.env.APP_ENV = 'test';
 });
+
+test('loader is not called get called when option is disabled', () => {
+  const testConfig = loadConfig('test/fixtures/javascript', {
+    files: false,
+    environment: false,
+    secrets: false
+  });
+
+  expect(testConfig).toEqual({});
+});


### PR DESCRIPTION
I'd like to use config-dug for a front-end project, but don't want to inject all of process.env into the browser bundle, so I have added a flag to disable it (and other loaders) 

### Use case

In next.js:

```js
// next.config.js

const { loadConfig } = require('config-dug');

const publicConfig = loadConfig('./config/public', { environment: false, secrets: false });
const serverConfig = loadConfig('./config/server');

module.exports = {
    publicRuntimeConfig: {
      ...publicConfig,
    },
    serverRuntimeConfig: {
      ...serverConfig,
    },
}
```