### PR TITLE
Add feature to override aws secrets configs with environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0 (May 14, 2021)
+
+- Add feature to override aws secrets configs with environment variables
+
 ## 1.6.2 (December 4, 2020)
 
 - Update all console warnings to console logs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-dug",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Config loader with support for AWS Secrets Manager",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,11 +85,28 @@ const convertToArray = (value: string): string[] => {
     .filter(entry => !!entry);
 };
 
-const loadSecrets = (config: LoadSecretsArgs): object => {
-  const secretNames = config.AWS_SECRETS_MANAGER_NAMES || config.awsSecretsManagerNames;
-  const secretName = config.AWS_SECRETS_MANAGER_NAME || config.awsSecretsManagerName;
-  const region = config.AWS_SECRETS_MANAGER_REGION || config.awsSecretsManagerRegion || 'us-east-1';
-  const timeout = config.AWS_SECRETS_MANAGER_TIMEOUT || config.awsSecretsManagerTimeout || 5000;
+const loadSecrets = (config: LoadSecretsArgs, overrides: LoadSecretsArgs): object => {
+  const secretNames =
+    overrides.AWS_SECRETS_MANAGER_NAMES ||
+    config.AWS_SECRETS_MANAGER_NAMES ||
+    config.awsSecretsManagerNames;
+
+  const secretName =
+    overrides.AWS_SECRETS_MANAGER_NAME ||
+    config.AWS_SECRETS_MANAGER_NAME ||
+    config.awsSecretsManagerName;
+
+  const region =
+    overrides.AWS_SECRETS_MANAGER_REGION ||
+    config.AWS_SECRETS_MANAGER_REGION ||
+    config.awsSecretsManagerRegion ||
+    'us-east-1';
+
+  const timeout =
+    overrides.AWS_SECRETS_MANAGER_TIMEOUT ||
+    config.AWS_SECRETS_MANAGER_TIMEOUT ||
+    config.awsSecretsManagerTimeout ||
+    5000;
 
   const mergedSecretNames = new Set<string>();
 
@@ -160,7 +177,15 @@ const loadConfig = (configPath = ''): ConfigObject => {
     localEnvironmentConfig,
     localConfig
   );
-  const config = Object.assign({}, fileConfig, loadSecrets(fileConfig), loadEnvironment());
+
+  const environmentVars = loadEnvironment();
+
+  const config = Object.assign(
+    {},
+    fileConfig,
+    loadSecrets(fileConfig, environmentVars),
+    environmentVars
+  );
 
   if (environment === 'test' || environment === 'development') {
     return config;

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -29,3 +29,18 @@ test('loading multiple AWS Secrets Manager secrets works', (): void => {
     TEST_ANOTHER_INTEGER: 23
   });
 });
+
+test('overriding AWS Secrets Manager secrets with env vars works', (): void => {
+  process.env.AWS_SECRETS_MANAGER_NAMES = 'development/config-dug-1';
+
+  const testConfig = loadConfig('test/fixtures/multiple-secrets');
+
+  expect(testConfig).toMatchObject({
+    AWS_SECRETS_MANAGER_NAMES: 'development/config-dug-1',
+    AWS_SECRETS_MANAGER_NAME: 'development/config-dug-1',
+    DB_USERNAME: 'config-dug',
+    DB_PASSWORD: 'secret',
+    TEST_BOOLEAN: true,
+    TEST_INTEGER: 42
+  });
+});


### PR DESCRIPTION
### Context
Config dug was attempting to load the aws secrets configs set in the config files even when an environment variable that should take precedence was being passed in.

### Description
This commit enables config-dug to use the provided environment variables
instead of reaching for aws secrets unnecessarily.