### PR TITLE
Correctly parse nested objects and arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.0 (September 13, 2024)
+
+- Enabled support for nested objects and arrays loaded from AWS Secrets
+
 ## 1.8.0 (August 21, 2024)
 
 - Upgrade to aws-sdk v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "config-dug",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "config-dug",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.635.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-dug",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Config loader with support for AWS Secrets Manager",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",

--- a/test/fixtures/secrets/aws-secrets-manager-response.json
+++ b/test/fixtures/secrets/aws-secrets-manager-response.json
@@ -1,7 +1,7 @@
 {
   "Name": "/aws/reference/secretsmanager/development/config-dug",
   "Type": "SecureString",
-  "Value": "{\"DB_USERNAME\":\"config-dug\",\"DB_PASSWORD\":\"secret\",\"TEST_BOOLEAN\":\"true\",\"TEST_INTEGER\":\"42\",\"TEST_FLOAT\":\"4.2\",\"TEST_NUMBER_LIST\":\"123456,123456\"}",
+  "Value": "{\"DB_USERNAME\":\"config-dug\",\"DB_PASSWORD\":\"secret\",\"TEST_BOOLEAN\":\"true\",\"TEST_INTEGER\":\"42\",\"TEST_FLOAT\":\"4.2\",\"TEST_NUMBER_LIST\":\"123456,123456\",\"TEST_NESTED\":{\"LEAF_1\":\"LEAF_1\",\"NUMBERS\":[1,2,3,4,5],\"STRINGS\":[\"a\",\"b\",\"c\"],\"OBJECTS\":[{\"a\":1},{\"b\":2},{\"c\":\"3\"}]}}",
   "Version": 0,
   "SourceResult": "{\"ARN\":\"arn:aws:secretsmanager:us-east-1:999999999999:secret:development/config-dug-qH33bS\",\"name\":\"development/config-dug\",\"versionId\":\"8439a2e1-9a24-49ff-b9e7-5e8ba5d6d5a6\",\"secretString\":\"{\\\"DB_USERNAME\\\":\\\"config-dug\\\",\\\"DB_PASSWORD\\\":\\\"secret\\\"}\",\"versionStages\":[\"AWSCURRENT\"],\"createdDate\":\"Apr 10, 2019 10:49:20 PM\"}",
   "LastModifiedDate": "2019-04-10T22:49:20.589Z",

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -13,6 +13,12 @@ test('loading secrets from AWS Secrets Manager works', (): void => {
     TEST_INTEGER: 42,
     TEST_FLOAT: 4.2,
     TEST_NUMBER_LIST: '123456,123456',
+    TEST_NESTED: {
+      LEAF_1: 'LEAF_1',
+      NUMBERS: [1, 2, 3, 4, 5],
+      STRINGS: ['a', 'b', 'c'],
+      OBJECTS: [{ a: 1 }, { b: 2 }, { c: 3 }],
+    },
   });
 });
 


### PR DESCRIPTION
Slight modification to allow `config-dug` to parse structures like this:

```js
{
  DB_USERNAME: "config-dug",
  // ...
  TEST_NESTED: {
    LEAF_1: "LEAF_1",
    NUMBERS: [1, 2, 3, 4, 5],
    STRINGS: ["a", "b", "c"],
    OBJECTS: [{ a: 1 }, { b: 2 }, { c: "3" }],
  },
}
```

Note the `"3"` (string) inside `OBJECTS` - it will still correctly parse this as `3` (integer).