### PR TITLE
ENGCB-379 - Update README file with Publishing instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In such cases, publishing an alpha version for use in other environments can be 
 
 ### Beta versions (Release candidate)
 
-In some rare situations we need to test Library changes versions on a few services in Production, before rolling out this change to all services that uses the library. How it works:
+In some rare situations, we need to test library change versions on a few services in production before rolling out the change to all services that use the library. How it works:
 
 1. Make sure the version in `package.json` is following this format: `<<major>>.<<minor>>.<<patch>>-beta.<<beta version>>` (e.g. `1.2.5-beta.0`, `1.2.5-beta.1`, etc.).
 1. Make sure all changes including the version bump, lock file and your library changes are committed and pushed to your feature branch.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,35 @@ Config management library for Node.js with support for multiple environments, co
 - [@config-dug/service-cjs-ts-tsyringe](./examples/service-cjs-ts-tsyringe): TypeScript CJS test service with [TSyringe](https://github.com/microsoft/tsyringe)
 - [@config-dug/service-esm-ts](./examples/service-esm-ts): TypeScript ESM test service
 
-## Publishing Prerelease Versions
+## Publishing
 
-1. Increment the version number in `package.json` in the package you want to publish (not the `package.json` in the project root)
-1. Run `npm publish --tag next` in the package your want to publish (not in the project root)
+### Alpha versions
+
+Sometimes, testing functionality locally using symlinks can be challenging.
+In such cases, publishing an alpha version for use in other environments can be a practical way to test new changes.
+
+1. Make sure the version in `package.json` is following this format: `<<major>>.<<minor>>.<<patch>>-alpha.<<alpha version>>` (e.g. `1.2.5-alpha.0`, `1.2.5-alpha.1`, etc.).
+1. Make sure all changes including the version bump, lock file and your library changes are committed and pushed to your feature branch.
+1. Run `npm publish --tag alpha` (To be able to publish the new NPM package the user should be included on the [NPM Publisher List](https://www.npmjs.com/settings/neofinancial/teams/team/publishers/users). If you're not on that list ask for help to publish.)
+
+### Beta versions (Release candidate)
+
+In some rare situations we need to test Library changes versions on a few services in Production, before rolling out this change to all services that uses the library. How it works:
+
+1. Make sure the version in `package.json` is following this format: `<<major>>.<<minor>>.<<patch>>-beta.<<beta version>>` (e.g. `1.2.5-beta.0`, `1.2.5-beta.1`, etc.).
+1. Make sure all changes including the version bump, lock file and your library changes are committed and pushed to your feature branch.
+1. Open a Pull Request targeting the merge to a branch that matches with the following pattern: "\**/*release-candidate\*"
+1. After getting approvals, merge your changes into the Release Candidate branch;
+1. Run `npm publish --tag beta` (To be able to publish the new NPM package the user should be included on the [NPM Publisher List](https://www.npmjs.com/settings/neofinancial/teams/team/publishers/users). If you're not on that list ask for help to publish.)
+
+### Stable versions
+
+Once your changes have been tested and you're ready to publish a stable version, open your Pull Request, get approvals, merge it and publish the new package version. How it works:
+
+1. Make sure the version in `package.json` is following this format: `<<major>>.<<minor>>.<<patch>>` (e.g. `1.2.5`, `1.3.0`, etc.).
+1. Make sure all changes including the version bump, lock file and your library changes are committed and pushed to your feature branch.
+1. Pull request is approved and merged into `master` branch;
+1. Run `npm publish --tag latest` (To be able to publish the new NPM package the user should be included on the [NPM Publisher List](https://www.npmjs.com/settings/neofinancial/teams/team/publishers/users). If you're not on that list ask for help to publish.)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In some rare situations we need to test Library changes versions on a few servic
 
 1. Make sure the version in `package.json` is following this format: `<<major>>.<<minor>>.<<patch>>-beta.<<beta version>>` (e.g. `1.2.5-beta.0`, `1.2.5-beta.1`, etc.).
 1. Make sure all changes including the version bump, lock file and your library changes are committed and pushed to your feature branch.
-1. Open a Pull Request targeting the merge to a branch that matches with the following pattern: "\**/*release-candidate\*"
+1. Open a Pull Request targeting a branch that matches this pattern: `**/*release-candidate*`.
 1. After getting approvals, merge your changes into the Release Candidate branch;
 1. Run `npm publish --tag beta` (To be able to publish the new NPM package the user should be included on the [NPM Publisher List](https://www.npmjs.com/settings/neofinancial/teams/team/publishers/users). If you're not on that list ask for help to publish.)
 


### PR DESCRIPTION
### Description of changes

- **Updated** `README.md` publishing instructions:
  - **Alpha versions**: Replaced `neo library publish` (CodeBuild) with `npm publish --tag alpha` (manual).
  - **Beta versions**: Replaced automatic CodeBuild trigger on merge to release-candidate branches with `npm publish --tag beta` (manual).
  - **Stable versions**: Replaced automatic GitHub Actions + CodeBuild pipeline with `npm publish --tag latest` (manual).
  - Added a note about requiring access to the [NPM Publisher List](https://www.npmjs.com/settings/neofinancial/teams/team/publishers/users) for all publish flows.

### Why

As this public repository we won't be using automatic publishing through the package publisher CodeBuild pipeline. - [Relevant thread with Cyber Sec](https://neofinancial.slack.com/archives/C09QZRSH1LJ/p1770823155109949) (Private channel)

### Related PRs

- https://github.com/neofinancial/terraform-neo/pull/15305
- https://github.com/neofinancial/eslint-config-neo/pull/55

### Checklist

- ~[ ] Have you fully tested your PR locally?~
- ~[ ] Have you made a CHANGELOG entry?~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated publishing instructions with three distinct release flows: Alpha (with alpha version tags), Beta/Release Candidate (with PR and release-candidate branch requirements), and Stable (with master branch merge requirement).
  * Added explicit version-format requirements and NPM Publisher List permission notes for each publishing step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->